### PR TITLE
Redo sql executor

### DIFF
--- a/examples/dispatcher_service/src/csv2db.rs
+++ b/examples/dispatcher_service/src/csv2db.rs
@@ -6,7 +6,7 @@ use std::io::{Cursor, Write};
 
 use actix_multipart::Multipart;
 use actix_web::{HttpResponse, Result};
-use fabrix::{sql_adt, CsvReader, SqlWriter};
+use fabrix::{sql_adt, CsvReader, DatabaseSqlite, SqlWriter};
 use futures::{StreamExt, TryStreamExt};
 
 use crate::{get_current_time, AppError, UploadedFile, DB_CONN, FILE_TYPE_CSV, MULTIPART_KEY_FILE};
@@ -41,7 +41,7 @@ pub async fn csv_to_db(mut payload: Multipart) -> Result<HttpResponse> {
             let mut reader = CsvReader::new(buff);
             let fx = reader.finish(None).map_err(AppError::Fabrix)?;
 
-            let mut writer = SqlWriter::new_from_str(DB_CONN)
+            let mut writer = SqlWriter::<DatabaseSqlite>::new_from_str(DB_CONN)
                 .await
                 .map_err(AppError::Fabrix)?;
 

--- a/fabrix/src/bin/create_local_sqlite.rs
+++ b/fabrix/src/bin/create_local_sqlite.rs
@@ -1,0 +1,7 @@
+//! Create a local sqlite database
+
+// TODO:
+
+fn main() {
+    unimplemented!();
+}

--- a/fabrix/src/sources/sql/mod.rs
+++ b/fabrix/src/sources/sql/mod.rs
@@ -12,7 +12,5 @@ pub use reader::{Reader as SqlReader, SqlReadOptions};
 pub use sql_builder::builder::SqlBuilder;
 pub use sql_builder::interface::{DdlMutation, DdlQuery, DmlMutation, DmlQuery};
 pub use sql_builder::sql_adt;
-pub use sql_executor::{
-    DatabaseType, FabrixDatabaseLoader, SqlConnInfo, SqlEngine, SqlExecutor, SqlHelper,
-};
+pub use sql_executor::*;
 pub use writer::{SqlWriteOptions, Writer as SqlWriter};

--- a/fabrix/src/sources/sql/mod.rs
+++ b/fabrix/src/sources/sql/mod.rs
@@ -12,5 +12,7 @@ pub use reader::{Reader as SqlReader, SqlReadOptions};
 pub use sql_builder::builder::SqlBuilder;
 pub use sql_builder::interface::{DdlMutation, DdlQuery, DmlMutation, DmlQuery};
 pub use sql_builder::sql_adt;
-pub use sql_executor::{SqlConnInfo, SqlEngine, SqlExecutor, SqlHelper};
+pub use sql_executor::{
+    DatabaseType, FabrixDatabaseLoader, SqlConnInfo, SqlEngine, SqlExecutor, SqlHelper,
+};
 pub use writer::{SqlWriteOptions, Writer as SqlWriter};

--- a/fabrix/src/sources/sql/sql_executor/executor.rs
+++ b/fabrix/src/sources/sql/sql_executor/executor.rs
@@ -3,13 +3,12 @@
 use std::str::FromStr;
 
 use async_trait::async_trait;
-use sqlx::{MySqlPool, PgPool, SqlitePool};
 
 use super::{
     conn_e_err, conn_n_err,
     loader::{DatabaseType, LoaderTransaction},
     types::string_try_into_value_type,
-    FabrixDatabaseLoader, LoaderPool, SqlConnInfo,
+    FabrixDatabaseLoader, SqlConnInfo,
 };
 use crate::{
     sql_adt, D1Value, DdlMutation, DdlQuery, DmlMutation, DmlQuery, Fabrix, Series, SqlBuilder,
@@ -70,18 +69,18 @@ pub trait SqlEngine: SqlHelper {
 
 /// Executor is the core struct of db mod.
 /// It plays a role of CRUD and provides data manipulation functionality.
-pub struct SqlExecutor<L>
+pub struct SqlExecutor<T>
 where
-    L: FabrixDatabaseLoader<L> + DatabaseType,
+    T: DatabaseType,
 {
     driver: SqlBuilder,
     conn_str: String,
-    pool: Option<L>,
+    pool: Option<T>,
 }
 
-impl<L> SqlExecutor<L>
+impl<T> SqlExecutor<T>
 where
-    L: FabrixDatabaseLoader<L> + DatabaseType,
+    T: DatabaseType,
 {
     /// constructor
     pub fn new(conn_info: SqlConnInfo) -> Self {
@@ -93,9 +92,9 @@ where
     }
 }
 
-impl<L> FromStr for SqlExecutor<L>
+impl<T> FromStr for SqlExecutor<T>
 where
-    L: FabrixDatabaseLoader<L> + DatabaseType,
+    T: DatabaseType,
 {
     type Err = SqlError;
 
@@ -115,9 +114,9 @@ where
 }
 
 #[async_trait]
-impl<L> SqlHelper for SqlExecutor<L>
+impl<T> SqlHelper for SqlExecutor<T>
 where
-    L: FabrixDatabaseLoader<L> + DatabaseType,
+    T: DatabaseType,
 {
     async fn get_primary_key(&self, table_name: &str) -> SqlResult<String> {
         conn_n_err!(self.pool);
@@ -188,23 +187,13 @@ where
 }
 
 #[async_trait]
-impl<L> SqlEngine for SqlExecutor<L>
+impl<T> SqlEngine for SqlExecutor<T>
 where
-    L: FabrixDatabaseLoader<L> + DatabaseType,
+    T: DatabaseType,
 {
     async fn connect(&mut self) -> SqlResult<()> {
         conn_e_err!(self.pool);
-        match self.driver {
-            SqlBuilder::Mysql => MySqlPool::connect(&self.conn_str).await.map(|pool| {
-                self.pool = Some(LoaderPool::from(pool));
-            })?,
-            SqlBuilder::Postgres => PgPool::connect(&self.conn_str).await.map(|pool| {
-                self.pool = Some(LoaderPool::from(pool));
-            })?,
-            SqlBuilder::Sqlite => SqlitePool::connect(&self.conn_str).await.map(|pool| {
-                self.pool = Some(LoaderPool::from(pool));
-            })?,
-        }
+        self.pool = Some(T::connect(&self.conn_str).await?);
         Ok(())
     }
 
@@ -428,7 +417,11 @@ async fn txn_create_and_insert<'a>(
 mod test_executor {
 
     use super::*;
-    use crate::{datetime, fx, series, sql_adt::ExpressionTransit, xpr};
+    use crate::{
+        datetime, fx, series,
+        sql_adt::ExpressionTransit,
+        xpr, {DatabaseMysql, DatabasePg, DatabaseSqlite},
+    };
 
     const CONN1: &str = "mysql://root:secret@localhost:3306/dev";
     const CONN2: &str = "postgres://root:secret@localhost:5432/dev";
@@ -439,14 +432,14 @@ mod test_executor {
 
     #[tokio::test]
     async fn test_connection() {
-        let mut exc = SqlExecutor::from_str(CONN1).unwrap();
+        let mut exc = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
 
         exc.connect().await.expect("connection is ok");
     }
 
     #[tokio::test]
     async fn test_get_primary_key() {
-        let mut exc = SqlExecutor::from_str(CONN1).unwrap();
+        let mut exc = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
 
         exc.connect().await.expect("connection is ok");
 
@@ -455,7 +448,7 @@ mod test_executor {
 
     #[tokio::test]
     async fn test_save_and_select() {
-        let mut exc = SqlExecutor::from_str(CONN3).unwrap();
+        let mut exc = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
 
         exc.connect().await.expect("connection is ok");
 
@@ -482,7 +475,7 @@ mod test_executor {
 
     #[tokio::test]
     async fn test_save_quotes_into_sqlite() {
-        let mut exc = SqlExecutor::from_str(CONN3).unwrap();
+        let mut exc = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
 
         exc.connect().await.expect("connection is ok");
 
@@ -521,21 +514,21 @@ mod test_executor {
         let save_strategy = sql_adt::SaveStrategy::FailIfExists;
 
         // mysql
-        let mut exc = SqlExecutor::from_str(CONN1).unwrap();
+        let mut exc = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.save(TABLE_NAME, df.clone(), &save_strategy).await;
         println!("{:?}", res);
 
         // postgres
-        let mut exc = SqlExecutor::from_str(CONN2).unwrap();
+        let mut exc = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.save(TABLE_NAME, df.clone(), &save_strategy).await;
         println!("{:?}", res);
 
         // sqlite
-        let mut exc = SqlExecutor::from_str(CONN3).unwrap();
+        let mut exc = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.save(TABLE_NAME, df.clone(), &save_strategy).await;
@@ -565,21 +558,21 @@ mod test_executor {
         let save_strategy = sql_adt::SaveStrategy::Replace;
 
         // mysql
-        let mut exc = SqlExecutor::from_str(CONN1).unwrap();
+        let mut exc = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.save(TABLE_NAME, df.clone(), &save_strategy).await;
         assert!(res.is_ok());
 
         // postgres
-        let mut exc = SqlExecutor::from_str(CONN2).unwrap();
+        let mut exc = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.save(TABLE_NAME, df.clone(), &save_strategy).await;
         assert!(res.is_ok());
 
         // sqlite
-        let mut exc = SqlExecutor::from_str(CONN3).unwrap();
+        let mut exc = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.save(TABLE_NAME, df.clone(), &save_strategy).await;
@@ -606,21 +599,21 @@ mod test_executor {
         let save_strategy = sql_adt::SaveStrategy::Append;
 
         // mysql
-        let mut exc = SqlExecutor::from_str(CONN1).unwrap();
+        let mut exc = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.save(TABLE_NAME, df.clone(), &save_strategy).await;
         assert!(res.is_ok());
 
         // postgres
-        let mut exc = SqlExecutor::from_str(CONN2).unwrap();
+        let mut exc = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.save(TABLE_NAME, df.clone(), &save_strategy).await;
         assert!(res.is_ok());
 
         // sqlite
-        let mut exc = SqlExecutor::from_str(CONN3).unwrap();
+        let mut exc = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.save(TABLE_NAME, df.clone(), &save_strategy).await;
@@ -640,21 +633,21 @@ mod test_executor {
         let save_strategy = sql_adt::SaveStrategy::Upsert;
 
         // mysql
-        let mut exc = SqlExecutor::from_str(CONN1).unwrap();
+        let mut exc = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.save(TABLE_NAME, df.clone(), &save_strategy).await;
         assert!(res.is_ok());
 
         // postgres
-        let mut exc = SqlExecutor::from_str(CONN2).unwrap();
+        let mut exc = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.save(TABLE_NAME, df.clone(), &save_strategy).await;
         assert!(res.is_ok());
 
         // sqlite
-        let mut exc = SqlExecutor::from_str(CONN3).unwrap();
+        let mut exc = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.save(TABLE_NAME, df.clone(), &save_strategy).await;
@@ -679,21 +672,21 @@ mod test_executor {
         };
 
         // mysql
-        let mut exc = SqlExecutor::from_str(CONN1).unwrap();
+        let mut exc = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.delete(&delete).await;
         assert!(res.is_ok());
 
         // postgres
-        let mut exc = SqlExecutor::from_str(CONN2).unwrap();
+        let mut exc = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.delete(&delete).await;
         assert!(res.is_ok());
 
         // sqlite
-        let mut exc = SqlExecutor::from_str(CONN3).unwrap();
+        let mut exc = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.delete(&delete).await;
@@ -702,19 +695,19 @@ mod test_executor {
 
     #[tokio::test]
     async fn test_select_primary_key() {
-        let mut exc = SqlExecutor::from_str(CONN1).unwrap();
+        let mut exc = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.get_primary_key(TABLE_NAME).await;
         assert!(res.is_ok());
 
-        let mut exc = SqlExecutor::from_str(CONN2).unwrap();
+        let mut exc = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.get_primary_key(TABLE_NAME).await;
         assert!(res.is_ok());
 
-        let mut exc = SqlExecutor::from_str(CONN3).unwrap();
+        let mut exc = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.get_primary_key(TABLE_NAME).await;
@@ -739,7 +732,7 @@ mod test_executor {
         };
 
         // mysql
-        let mut exc = SqlExecutor::from_str(CONN1).unwrap();
+        let mut exc = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let df = exc.select(&select).await.unwrap();
@@ -748,7 +741,7 @@ mod test_executor {
         assert!(df.height() > 0);
 
         // postgres
-        let mut exc = SqlExecutor::from_str(CONN2).unwrap();
+        let mut exc = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let df = exc.select(&select).await.unwrap();
@@ -757,7 +750,7 @@ mod test_executor {
         assert!(df.height() > 0);
 
         // sqlite
-        let mut exc = SqlExecutor::from_str(CONN3).unwrap();
+        let mut exc = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let df = exc.select(&select).await.unwrap();
@@ -769,7 +762,7 @@ mod test_executor {
     #[tokio::test]
     async fn test_get_table_schema() {
         // mysql
-        let mut exc = SqlExecutor::from_str(CONN1).unwrap();
+        let mut exc = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let schema = exc.get_table_schema(TABLE_NAME).await.unwrap();
@@ -777,7 +770,7 @@ mod test_executor {
         assert!(!schema.is_empty());
 
         // pg
-        let mut exc = SqlExecutor::from_str(CONN2).unwrap();
+        let mut exc = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let schema = exc.get_table_schema(TABLE_NAME).await.unwrap();
@@ -785,7 +778,7 @@ mod test_executor {
         assert!(!schema.is_empty());
 
         // sqlite
-        let mut exc = SqlExecutor::from_str(CONN3).unwrap();
+        let mut exc = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let schema = exc.get_table_schema(TABLE_NAME).await.unwrap();
@@ -798,7 +791,7 @@ mod test_executor {
         let ids = series!("ord" => [10,11,14,20,21]);
 
         // mysql
-        let mut exc = SqlExecutor::from_str(CONN1).unwrap();
+        let mut exc = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.get_existing_ids(TABLE_NAME, &ids).await;
@@ -806,7 +799,7 @@ mod test_executor {
         println!("{:?}", res.unwrap());
 
         // pg
-        let mut exc = SqlExecutor::from_str(CONN2).unwrap();
+        let mut exc = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.get_existing_ids(TABLE_NAME, &ids).await;
@@ -814,7 +807,7 @@ mod test_executor {
         println!("{:?}", res.unwrap());
 
         // sqlite
-        let mut exc = SqlExecutor::from_str(CONN3).unwrap();
+        let mut exc = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
         exc.connect().await.expect("connection is ok");
 
         let res = exc.get_existing_ids(TABLE_NAME, &ids).await;

--- a/fabrix/src/sources/sql/sql_executor/mod.rs
+++ b/fabrix/src/sources/sql/sql_executor/mod.rs
@@ -15,7 +15,7 @@ pub mod processor;
 pub mod types;
 
 pub use executor::{SqlEngine, SqlExecutor, SqlHelper};
-pub(crate) use loader::{FabrixDatabaseLoader, LoaderPool};
+pub use loader::{DatabaseType, FabrixDatabaseLoader, LoaderPool};
 pub(crate) use macros::*;
 pub(crate) use processor::SqlRowProcessor;
 

--- a/fabrix/src/sources/sql/sql_executor/mod.rs
+++ b/fabrix/src/sources/sql/sql_executor/mod.rs
@@ -15,7 +15,7 @@ pub mod processor;
 pub mod types;
 
 pub use executor::{SqlEngine, SqlExecutor, SqlHelper};
-pub use loader::{DatabaseType, FabrixDatabaseLoader, LoaderPool};
+pub use loader::*;
 pub(crate) use macros::*;
 pub(crate) use processor::SqlRowProcessor;
 

--- a/fabrix/src/sources/sql/sql_executor/types.rs
+++ b/fabrix/src/sources/sql/sql_executor/types.rs
@@ -20,7 +20,7 @@ const MISMATCHED_SQL_ROW: &str = "mismatched sql row";
 pub(crate) type OptMarker = Option<&'static dyn SqlTypeTagMarker>;
 
 /// Type of Sql row
-pub(crate) enum SqlRow {
+pub enum SqlRow {
     Mysql(MySqlRow),
     Pg(PgRow),
     Sqlite(SqliteRow),

--- a/fabrix/tests/dispatcher_tests.rs
+++ b/fabrix/tests/dispatcher_tests.rs
@@ -6,8 +6,8 @@ use std::fs::File;
 use std::path::Path;
 
 use fabrix::{
-    sql_adt, CsvReadOptions, CsvReader, Dispatcher, ParquetWriteOptions, ParquetWriter, SqlEngine,
-    SqlReadOptions, SqlReader, SqlWriteOptions, SqlWriter,
+    sql_adt, CsvReadOptions, CsvReader, DatabaseSqlite, Dispatcher, ParquetWriteOptions,
+    ParquetWriter, SqlEngine, SqlReadOptions, SqlReader, SqlWriteOptions, SqlWriter,
 };
 
 const CSV_READ: &str = "../mock/test.csv";
@@ -18,7 +18,7 @@ const TABLE: &str = "dispatcher_test";
 #[tokio::test]
 async fn read_csv_write_db() {
     let reader = CsvReader::new(File::open(CSV_READ).expect("file not found"));
-    let writer = SqlWriter::new_from_str(CONN)
+    let writer = SqlWriter::<DatabaseSqlite>::new_from_str(CONN)
         .await
         .expect("cannot establish connection");
 
@@ -57,7 +57,7 @@ async fn read_csv_write_db() {
 
 #[tokio::test]
 async fn read_db_write_parquet() {
-    let reader = SqlReader::new_from_str(CONN)
+    let reader = SqlReader::<DatabaseSqlite>::new_from_str(CONN)
         .await
         .expect("cannot establish connection");
     let writer = ParquetWriter::new(File::create(PARQUET_WRITE).expect("file cannot be created"));

--- a/fabrix/tests/read_xl_to_db_test.rs
+++ b/fabrix/tests/read_xl_to_db_test.rs
@@ -5,7 +5,7 @@
 
 use std::fs::File;
 
-use fabrix::prelude::*;
+use fabrix::{prelude::*, DatabasePg};
 
 // const CONN1: &str = "mysql://root:secret@localhost:3306/dev";
 const CONN2: &str = "postgres://root:secret@localhost:5432/dev";
@@ -21,9 +21,9 @@ const SQL_TABLE_NAME: &str = "test_xl2db";
 async fn test_xl2db_async_no_index() {
     let source: XlWorkbook<File> = XlSource::Path(XL_PATH.to_owned()).try_into().unwrap();
 
-    let mut xl2db = XlDbHelper::new(CONN2).await.unwrap();
+    let mut xl2db = XlDbHelper::<DatabasePg>::new(CONN2).await.unwrap();
 
-    let mut xle = XlDbExecutor::new_with_source(source);
+    let mut xle = XlDbExecutor::<File, DatabasePg>::new_with_source(source);
 
     let res = xle
         .async_consume_fn_mut(
@@ -84,9 +84,9 @@ async fn test_xl2db_async_no_index() {
 async fn test_xl2db_async_with_index_row_wised() {
     let source: XlWorkbook<File> = XlSource::Path(XL_PATH.to_owned()).try_into().unwrap();
 
-    let mut xl2db = XlDbHelper::new(CONN2).await.unwrap();
+    let mut xl2db = XlDbHelper::<DatabasePg>::new(CONN2).await.unwrap();
 
-    let mut xle = XlDbExecutor::new_with_source(source);
+    let mut xle = XlDbExecutor::<File, DatabasePg>::new_with_source(source);
 
     let res = xle
         .async_consume_fn_mut(
@@ -113,9 +113,9 @@ async fn test_xl2db_async_with_index_row_wised() {
 async fn test_xl2db_async_with_index_col_wised() {
     let source: XlWorkbook<File> = XlSource::Path(XL_PATH.to_owned()).try_into().unwrap();
 
-    let xl2db = XlDbHelper::new(CONN2).await.unwrap();
+    let xl2db = XlDbHelper::<DatabasePg>::new(CONN2).await.unwrap();
 
-    let mut xle = XlDbExecutor::new_with_source(source);
+    let mut xle = XlDbExecutor::<File, DatabasePg>::new_with_source(source);
 
     let res = xle
         .async_consume_fn_mut(

--- a/fabrix/tests/sql_executor_test.rs
+++ b/fabrix/tests/sql_executor_test.rs
@@ -14,6 +14,7 @@ use std::str::FromStr;
 use fabrix::sql_adt::ExpressionTransit;
 use fabrix::{datetime, fx, xpr};
 use fabrix::{sql_adt, SqlEngine, SqlExecutor};
+use fabrix::{DatabaseMysql, DatabasePg, DatabaseSqlite};
 
 const CONN1: &str = "mysql://root:secret@localhost:3306/dev";
 const CONN2: &str = "postgres://root:secret@localhost:5432/dev";
@@ -49,9 +50,9 @@ cargo test --package fabrix --test sql_executor_test -- test_connection --exact 
 */
 #[tokio::test]
 async fn test_connection() {
-    let mut exc1 = SqlExecutor::from_str(CONN1).unwrap();
-    let mut exc2 = SqlExecutor::from_str(CONN2).unwrap();
-    let mut exc3 = SqlExecutor::from_str(CONN3).unwrap();
+    let mut exc1 = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
+    let mut exc2 = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
+    let mut exc3 = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
 
     let r1 = exc1.connect().await;
     assert!(r1.is_ok());
@@ -86,21 +87,21 @@ async fn test_save_fail_if_exists() {
     let save_strategy = sql_adt::SaveStrategy::FailIfExists;
 
     // mysql
-    let mut exc1 = SqlExecutor::from_str(CONN1).unwrap();
+    let mut exc1 = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
     exc1.connect().await.expect("connection is ok");
 
     let res1 = exc1.save(TABLE_NAME, df.clone(), &save_strategy).await;
     assert!(res1.is_ok());
 
     // postgres
-    let mut exc2 = SqlExecutor::from_str(CONN2).unwrap();
+    let mut exc2 = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
     exc2.connect().await.expect("connection is ok");
 
     let res2 = exc2.save(TABLE_NAME, df.clone(), &save_strategy).await;
     assert!(res2.is_ok());
 
     // sqlite
-    let mut exc3 = SqlExecutor::from_str(CONN3).unwrap();
+    let mut exc3 = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
     exc3.connect().await.expect("connection is ok");
 
     let res3 = exc3.save(TABLE_NAME, df.clone(), &save_strategy).await;
@@ -133,21 +134,21 @@ async fn test_save_replace() {
     let save_strategy = sql_adt::SaveStrategy::Replace;
 
     // mysql
-    let mut exc1 = SqlExecutor::from_str(CONN1).unwrap();
+    let mut exc1 = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
     exc1.connect().await.expect("connection is ok");
 
     let res1 = exc1.save(TABLE_NAME, df.clone(), &save_strategy).await;
     assert!(res1.is_ok());
 
     // postgres
-    let mut exc2 = SqlExecutor::from_str(CONN2).unwrap();
+    let mut exc2 = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
     exc2.connect().await.expect("connection is ok");
 
     let res2 = exc2.save(TABLE_NAME, df.clone(), &save_strategy).await;
     assert!(res2.is_ok());
 
     // sqlite
-    let mut exc3 = SqlExecutor::from_str(CONN3).unwrap();
+    let mut exc3 = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
     exc3.connect().await.expect("connection is ok");
 
     let res3 = exc3.save(TABLE_NAME, df.clone(), &save_strategy).await;
@@ -177,21 +178,21 @@ async fn test_save_append() {
     let save_strategy = sql_adt::SaveStrategy::Append;
 
     // mysql
-    let mut exc1 = SqlExecutor::from_str(CONN1).unwrap();
+    let mut exc1 = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
     exc1.connect().await.expect("connection is ok");
 
     let res1 = exc1.save(TABLE_NAME, df.clone(), &save_strategy).await;
     assert!(res1.is_ok());
 
     // postgres
-    let mut exc2 = SqlExecutor::from_str(CONN2).unwrap();
+    let mut exc2 = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
     exc2.connect().await.expect("connection is ok");
 
     let res2 = exc2.save(TABLE_NAME, df.clone(), &save_strategy).await;
     assert!(res2.is_ok());
 
     // sqlite
-    let mut exc3 = SqlExecutor::from_str(CONN3).unwrap();
+    let mut exc3 = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
     exc3.connect().await.expect("connection is ok");
 
     let res3 = exc3.save(TABLE_NAME, df.clone(), &save_strategy).await;
@@ -214,21 +215,21 @@ async fn test_save_upsert() {
     let save_strategy = sql_adt::SaveStrategy::Upsert;
 
     // mysql
-    let mut exc1 = SqlExecutor::from_str(CONN1).unwrap();
+    let mut exc1 = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
     exc1.connect().await.expect("connection is ok");
 
     let res1 = exc1.save(TABLE_NAME, df.clone(), &save_strategy).await;
     assert!(res1.is_ok());
 
     // postgres
-    let mut exc2 = SqlExecutor::from_str(CONN2).unwrap();
+    let mut exc2 = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
     exc2.connect().await.expect("connection is ok");
 
     let res2 = exc2.save(TABLE_NAME, df.clone(), &save_strategy).await;
     assert!(res2.is_ok());
 
     // sqlite
-    let mut exc3 = SqlExecutor::from_str(CONN3).unwrap();
+    let mut exc3 = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
     exc3.connect().await.expect("connection is ok");
 
     let res3 = exc3.save(TABLE_NAME, df.clone(), &save_strategy).await;
@@ -256,21 +257,21 @@ async fn test_delete() {
     };
 
     // mysql
-    let mut exc1 = SqlExecutor::from_str(CONN1).unwrap();
+    let mut exc1 = SqlExecutor::<DatabaseMysql>::from_str(CONN1).unwrap();
     exc1.connect().await.expect("connection is ok");
 
     let res1 = exc1.delete(&delete).await;
     assert!(res1.is_ok());
 
     // postgres
-    let mut exc2 = SqlExecutor::from_str(CONN2).unwrap();
+    let mut exc2 = SqlExecutor::<DatabasePg>::from_str(CONN2).unwrap();
     exc2.connect().await.expect("connection is ok");
 
     let res2 = exc2.delete(&delete).await;
     assert!(res2.is_ok());
 
     // sqlite
-    let mut exc3 = SqlExecutor::from_str(CONN3).unwrap();
+    let mut exc3 = SqlExecutor::<DatabaseSqlite>::from_str(CONN3).unwrap();
     exc3.connect().await.expect("connection is ok");
 
     let res3 = exc3.delete(&delete).await;


### PR DESCRIPTION
SqlExecutor no longer needs trait object of database pool, use generic type instead